### PR TITLE
Add simple counter screen

### DIFF
--- a/MyNewApp/README.md
+++ b/MyNewApp/README.md
@@ -25,6 +25,10 @@ In the output, you'll find options to open the app in a
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
+This project also contains a very simple counter screen which you can find in
+`app/(tabs)/counter.tsx`. A "Counter" tab has been added to the bottom
+navigation so you can experiment with basic React state handling.
+
 ## Get a fresh project
 
 When you're ready, run:
@@ -34,6 +38,29 @@ npm run reset-project
 ```
 
 This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+
+## Run lint checks
+
+This starter does not include automated tests yet, but you can run the built-in
+lint rules to verify the project:
+
+```bash
+npm run lint
+```
+
+The command uses Expo's lint configuration to check your TypeScript and
+JavaScript files.
+
+## Build an Android APK
+
+If you have Android Studio installed, you can generate an APK for testing with:
+
+```bash
+npx expo run:android --variant release
+```
+
+This will prebuild the native project if needed and assemble a release APK in
+`android/app/build/outputs/apk/release`.
 
 ## Learn more
 

--- a/MyNewApp/app/(tabs)/_layout.tsx
+++ b/MyNewApp/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="counter"
+        options={{
+          title: 'Counter',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="plus.circle.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/MyNewApp/app/(tabs)/counter.tsx
+++ b/MyNewApp/app/(tabs)/counter.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function CounterScreen() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.count}>Count: {count}</Text>
+      <Button title="Increase" onPress={() => setCount(count + 1)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+  count: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- add a counter example screen to learn basic state management
- wire the counter screen into the tab layout
- document linting and APK export steps in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860336d3ed4832fb2a45f8c8dea9e80